### PR TITLE
Only include the await! macro when compiling with nightly Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ unstable = []
 
 [dev-dependencies]
 futures = "0.1.17"
+
+[build-dependencies]
+version_check = "0.9"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+extern crate version_check;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    match version_check::Channel::read() {
+        Some(c) if c.is_nightly() => println!("cargo:rustc-cfg=nightly"),
+        _ => (),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,8 +74,10 @@
 //! [`block!`], [`try_nb!`] and [`await!`] macros to adapt it for blocking
 //! operation, or for non-blocking operation with `futures` or `await`.
 //!
-//! **NOTE** Currently, both `try_nb!` and `await!` are feature gated behind the `unstable` Cargo
+//! **NOTE**: Currently, both `try_nb!` and `await!` are feature gated behind the `unstable` Cargo
 //! feature.
+//!
+//! **NOTE2**: The `await!` macro is only available when compiling on nightly Rust.
 //!
 //! [`block!`]: macro.block.html
 //! [`try_nb!`]: macro.try_nb.html
@@ -429,7 +431,7 @@ impl<E> From<E> for Error<E> {
 ///
 /// - `Ok(t)` if `$e` evaluates to `Ok(t)`
 /// - `Err(e)` if `$e` evaluates to `Err(nb::Error::Other(e))`
-#[cfg(feature = "unstable")]
+#[cfg(nightly)]
 #[macro_export]
 macro_rules! await {
     ($e:expr) => {


### PR DESCRIPTION
In preparation to removing the unstable feature, I think it would be interesting not to include the `await!` macro on non-nightly builds, since it cannot work.
docs.rs uses nightly Rust for the generation so the macro will be there.

Disadvantadges:
- It may be confusing not to have the macro when attempting to use it on non-nightly Rust although it is there in the docs.

Thoughts?
