### PR TITLE
Document current MSRV

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ This project is developed and maintained by the [HAL team][team].
 
 ## [Documentation](https://docs.rs/nb)
 
+## Minimum Supported Rust Version (MSRV)
+
+This crate is guaranteed to compile on stable Rust 1.35 and up. It *might*
+compile with older versions but that may change in any new patch release.
+
 ## License
 
 Licensed under either of


### PR DESCRIPTION
This documents the MSRV used in CI, however, this crate builds with a much older Rust version.
Would there be interest in lowering it?