### PR TITLE
Fix defmt feature name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Add `defmt` as optional dependency and implement `defmt::Format` for `Error<E: defmt::Format>`, enabled by `defmt-0.3` unstable feature.
+- Add `defmt` as optional dependency and implement `defmt::Format` for `Error<E: defmt::Format>`, enabled by `defmt-0-3` unstable feature.
 
 ## [v1.0.0] - 2020-07-07
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 rust-version = "1.60"
 
 [features]
-"defmt-0.3" = ["dep:defmt"]
+"defmt-0-3" = ["dep:defmt"]
 
 [dependencies]
 defmt = {version = "0.3", optional = true}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,7 @@
 //!
 //! # Features
 //!
-//! - `defmt-0.3` - unstable feature which adds [`defmt::Format`] impl for [`Error`].
+//! - `defmt-0-3` - unstable feature which adds [`defmt::Format`] impl for [`Error`].
 
 #![no_std]
 
@@ -206,7 +206,7 @@ pub enum Error<E> {
     WouldBlock,
 }
 
-#[cfg(feature = "defmt-0.3")]
+#[cfg(feature = "defmt-0-3")]
 impl<E> defmt::Format for Error<E>
 where
     E: defmt::Format,


### PR DESCRIPTION
crates.io doesn't allow `.` in feature names:

> the remote server responded with an error: invalid upload request: invalid value: string "defmt-0.3", expected a valid feature name containing only letters, numbers, '-', '+', or '_' at line 1 column 182