### PR TITLE
fix: Update MSRV in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/nb"
 readme = "README.md"
 version = "1.1.0"
 edition = "2018"
-rust-version = "1.60"
+rust-version = "1.62"
 
 [features]
 "defmt-0-3" = ["dep:defmt"]


### PR DESCRIPTION
Closes https://github.com/rust-embedded/nb/issues/43

The MSRV was bumped in https://github.com/rust-embedded/nb/pull/42 but missed the `package.rust-version` metadata.